### PR TITLE
changes the way the window is obtained to get the correct window object

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 React [higher-order component](https://gist.github.com/sebmarkbage/ef0bf1f338a7182b6775) to get dimensions of container
 
 
-### `Dimensions([options])`
+### `Dimensions([options], [options.getHeight], [options.getWidth])`
 
 Wraps a react component and adds properties `containerHeight` and
 `containerWidth`. Useful for responsive design. Properties update on
@@ -34,14 +34,13 @@ import React from 'react'
 import Dimensions from 'react-dimensions'
 
 class MyComponent extends React.Component {
-  render() {
-    return (
-      <div 
-        containerWidth={ this.props.containerWidth } 
-        containerHeight={ this.props.containerHeight }>
-      </div>
-      )
-  }
+  render() (
+    <div
+      containerWidth={this.props.containerWidth}
+      containerHeight={this.props.containerHeight}
+    >
+    </div>
+  )
 }
 
 export default Dimensions()(MyComponent) // Enhanced component
@@ -54,15 +53,14 @@ var React = require('react')
 var Dimensions = require('react-dimensions')
 
 var MyComponent = React.createClass({
-  render: function() {
-    return (
-      <div 
-        containerWidth={ this.props.containerWidth } 
-        containerHeight={ this.props.containerHeight }>
-      </div>
-      );
-  }
-})
+  render: function() {(
+    <div
+      containerWidth={this.props.containerWidth}
+      containerHeight={this.props.containerHeight}
+    >
+    </div>
+  )}
+}
 
 module.exports = Dimensions()(MyComponent) // Enhanced component
 ```

--- a/index.jsx
+++ b/index.jsx
@@ -106,7 +106,7 @@ export default function Dimensions ({ getHeight = defaultGetHeight, getWidth = d
       }
 
       getWindow () {
-        return this.refs.container.ownerDocument.defaultView || window;
+        return this.refs.container ? (this.refs.container.ownerDocument.defaultView || window) : window;
       }
 
       componentDidMount () {

--- a/index.jsx
+++ b/index.jsx
@@ -106,7 +106,7 @@ export default function Dimensions ({ getHeight = defaultGetHeight, getWidth = d
       }
 
       getWindow () {
-        return this.refs.container ? (this.refs.container.ownerDocument.defaultView || window) : window
+        return this.refs.container ? (this.refs.container.ownerDocument.defaultView || window) : window;
       }
 
       componentDidMount () {
@@ -114,9 +114,13 @@ export default function Dimensions ({ getHeight = defaultGetHeight, getWidth = d
         this.getWindow().addEventListener('resize', this.onResize, false)
       }
 
+      /* disabling because recursion, read comment here:
+        https://github.com/digidem/react-dimensions/commit/de63939be6a15a9acc441665a8c103cb82443f85
+
       componentDidUpdate () {
         this.updateDimensions()
       }
+      */
 
       componentWillUnmount () {
         this.getWindow().removeEventListener('resize', this.onResize)

--- a/index.jsx
+++ b/index.jsx
@@ -99,15 +99,19 @@ export default function Dimensions ({ getHeight = defaultGetHeight, getWidth = d
 
       onResize = () => {
         if (this.rqf) return
-        this.rqf = window.requestAnimationFrame(() => {
+        this.rqf = this.getWindow().requestAnimationFrame(() => {
           this.rqf = null
           this.updateDimensions()
         })
       }
 
+      getWindow () {
+        return this.refs.container.ownerDocument.defaultView || window;
+      }
+
       componentDidMount () {
         this.updateDimensions()
-        window.addEventListener('resize', this.onResize, false)
+        this.getWindow().addEventListener('resize', this.onResize, false)
       }
 
       componentDidUpdate () {
@@ -115,7 +119,7 @@ export default function Dimensions ({ getHeight = defaultGetHeight, getWidth = d
       }
 
       componentWillUnmount () {
-        window.removeEventListener('resize', this.onResize)
+        this.getWindow().removeEventListener('resize', this.onResize)
       }
 
       render () {

--- a/index.jsx
+++ b/index.jsx
@@ -106,7 +106,7 @@ export default function Dimensions ({ getHeight = defaultGetHeight, getWidth = d
       }
 
       getWindow () {
-        return this.refs.container ? (this.refs.container.ownerDocument.defaultView || window) : window;
+        return this.refs.container ? (this.refs.container.ownerDocument.defaultView || window) : window
       }
 
       componentDidMount () {


### PR DESCRIPTION
closes #21

also removes a `componentDidUpdate()` recursion that was causing a maximum call stack exceeded exception, needs a separate fix
