### PR TITLE
Support getWrappedInstance for accessing the composed component

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -137,11 +137,19 @@ module.exports = function Dimensions ({
         this.getWindow().removeEventListener('resize', this.onResize)
       }
 
+      getWrappedInstance = () => this.refs.wrappedInstance;
+
       render () {
         return (
           <div style={containerStyle} ref='container'>
             {(this.state.containerWidth || this.state.containerHeight) &&
-              <ComposedComponent {...this.state} {...this.props} updateDimensions={this.updateDimensions}/>}
+              <ComposedComponent
+                {...this.state}
+                {...this.props}
+                updateDimensions={this.updateDimensions}
+                ref='wrappedInstance'
+              />
+            }
           </div>
         )
       }


### PR DESCRIPTION
Similar functionality to react-redux's connect wrapper's `getWrappedInstance` https://github.com/reactjs/react-redux/blob/master/docs/api.md#getwrappedinstance-reactcomponent.

This is useful for when you want to invoke a function on the wrapped component via refs
