### PR TITLE
Allow the ability to control className on wrapper div

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ or as an [ES7 class decorator](https://github.com/wycats/javascript-decorators)
     -   `options.containerStyle` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)=** A style object for the `<div>` that will wrap your component.
         If you are using a flexbox layout you will need to style this `div` rather than your wrapped component (because flexbox only works with direct children). The default style is
         `{ margin: 0, padding: 0, border: 0 }`.
+    -   `options.className` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)=** Control the class name set on the wrapper `<div>`
     -   `options.elementResize` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)=** Set true to watch the wrapper `div` for changes in
         size which are not a result of window resizing - e.g. changes to the flexbox and other layout. (optional, default `false`)
 

--- a/example.jsx
+++ b/example.jsx
@@ -21,7 +21,7 @@ class MyComponent extends React.Component {
   }
 }
 
-const EnhancedComponent = Dimensions({elementResize: true})(MyComponent)
+const EnhancedComponent = Dimensions({elementResize: true, className: 'react-dimensions-wrapper'})(MyComponent)
 
 const div = document.createElement('div')
 document.body.appendChild(div)

--- a/index.jsx
+++ b/index.jsx
@@ -35,6 +35,7 @@ function defaultGetHeight (element) {
  * The dimensions of this `div` are what are passed as props to your component. The default style is
  * `{ width: '100%', height: '100%', padding: 0, border: 0 }` which will cause the `div` to fill its
  * parent in most cases. If you are using a flexbox layout you will want to change this default style.
+ * @param {string} [options.className] Control the class name set on the wrapper `<div>`
  * @param {boolean} [options.elementResize=false] Set true to watch the wrapper `div` for changes in
  * size which are not a result of window resizing - e.g. changes to the flexbox and other layout.
  * @return {function}                   A higher-order component that can be
@@ -79,6 +80,7 @@ module.exports = function Dimensions ({
     getHeight = defaultGetHeight,
     getWidth = defaultGetWidth,
     containerStyle = defaultContainerStyle,
+    className = null,
     elementResize = false
   } = {}) {
   return (ComposedComponent) => {
@@ -154,7 +156,7 @@ module.exports = function Dimensions ({
           console.warn('Wrapper div has no height or width, try overriding style with `containerStyle` option')
         }
         return (
-          <div style={containerStyle} ref='container'>
+          <div className={className} style={containerStyle} ref='container'>
             {(containerWidth || containerHeight) &&
               <ComposedComponent
                 {...this.state}


### PR DESCRIPTION
This will help our use-cases in avoiding DIV-itis (since we're replacing a div that previously was already 100% width/height anyways)
