### PR TITLE
Add option to debounce onResize callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ or as an [ES7 class decorator](https://github.com/wycats/javascript-decorators)
         height, where element is the wrapper div. Defaults to `(element) => element.clientHeight`
     -   `options.getWidth` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)=** A function that is passed an element and returns element
         width, where element is the wrapper div. Defaults to `(element) => element.clientWidth`
+    -   `options.debounce` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Optionally debounce the `onResize` callback function by 
+        supplying the delay time in milliseconds. This will prevent excessive dimension 
+        updates. See <https://lodash.com/docs#debounce> for more information. Defaults to `0`, which disables debouncing. 
+    -   `options.debounceOpts` **\[[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Options to pass to the debounce function. See 
+        <https://lodash.com/docs#debounce> for all available options. Defaults to `{}`.
     -   `options.containerStyle` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)=** A style object for the `<div>` that will wrap your component.
         If you are using a flexbox layout you will need to style this `div` rather than your wrapped component (because flexbox only works with direct children). The default style is
         `{ margin: 0, padding: 0, border: 0 }`.

--- a/index.jsx
+++ b/index.jsx
@@ -100,7 +100,9 @@ module.exports = function Dimensions ({
 
       // Using arrow functions and ES7 Class properties to autobind
       // http://babeljs.io/blog/2015/06/07/react-on-es6-plus/#arrow-functions
-      updateDimensions = () => {
+
+      // Immediate updateDimensions callback with no debounce
+      updateDimensionsImmediate = () => {
         const container = this._parent
         const containerWidth = getWidth(container)
         const containerHeight = getHeight(container)
@@ -111,18 +113,17 @@ module.exports = function Dimensions ({
         }
       }
 
-      // Immediate onResize callback with no debounce
-      onResizeImmediate = () => {
+      // Optionally-debounced updateDimensions callback
+      updateDimensions = debounce === 0 ? this.updateDimensionsImmediate
+        : _debounce(this.updateDimensionsImmediate, debounce, debounceOpts)
+
+      onResize = () => {
         if (this.rqf) return
         this.rqf = this.getWindow().requestAnimationFrame(() => {
           this.rqf = null
           this.updateDimensions()
         })
       }
-
-      // Optionally-debounced onResize callback
-      onResize = debounce === 0 ? this.onResizeImmediate
-        : _debounce(this.onResizeImmediate, debounce, debounceOpts)
 
       // If the component is mounted in a different window to the javascript
       // context, as with https://github.com/JakeGinnivan/react-popout

--- a/index.jsx
+++ b/index.jsx
@@ -1,3 +1,4 @@
+const _debounce = require('lodash.debounce')
 const React = require('react')
 const onElementResize = require('element-resize-event')
 
@@ -31,6 +32,12 @@ function defaultGetHeight (element) {
  * height, where element is the wrapper div. Defaults to `(element) => element.clientHeight`
  * @param {function} [options.getWidth]  A function that is passed an element and returns element
  * width, where element is the wrapper div. Defaults to `(element) => element.clientWidth`
+ * @param {number} [options.debounce] Optionally debounce the `onResize` callback function by
+ * supplying the delay time in milliseconds. This will prevent excessive dimension
+ * updates. See
+ * https://lodash.com/docs#debounce for more information. Defaults to `0`, which disables debouncing.
+ * @param {object} [options.debounceOpts] Options to pass to the debounce function. See
+ * https://lodash.com/docs#debounce for all available options. Defaults to `{}`.
  * @param {object} [options.containerStyle] A style object for the `<div>` that will wrap your component.
  * The dimensions of this `div` are what are passed as props to your component. The default style is
  * `{ width: '100%', height: '100%', padding: 0, border: 0 }` which will cause the `div` to fill its
@@ -79,6 +86,8 @@ function defaultGetHeight (element) {
 module.exports = function Dimensions ({
     getHeight = defaultGetHeight,
     getWidth = defaultGetWidth,
+    debounce = 0,
+    debounceOpts = {},
     containerStyle = defaultContainerStyle,
     className = null,
     elementResize = false
@@ -102,13 +111,18 @@ module.exports = function Dimensions ({
         }
       }
 
-      onResize = () => {
+      // Immediate onResize callback with no debounce
+      onResizeImmediate = () => {
         if (this.rqf) return
         this.rqf = this.getWindow().requestAnimationFrame(() => {
           this.rqf = null
           this.updateDimensions()
         })
       }
+
+      // Optionally-debounced onResize callback
+      onResize = debounce === 0 ? this.onResizeImmediate
+        : _debounce(this.onResizeImmediate, debounce, debounceOpts)
 
       // If the component is mounted in a different window to the javascript
       // context, as with https://github.com/JakeGinnivan/react-popout

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "element-resize-event": "^2.0.4"
+    "element-resize-event": "^2.0.4",
+    "lodash.debounce": "^4.0.6"
   }
 }


### PR DESCRIPTION
We would like to provide an option to debounce to the onResize function to prevent excessive dimension updates
