### PR TITLE
Fix issues with spurious warnings about sizing

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -152,7 +152,8 @@ module.exports = function Dimensions ({
 
       render () {
         const {containerWidth, containerHeight} = this.state
-        if (!containerWidth && !containerHeight) {
+        if (this._parent && !containerWidth && !containerHeight) {
+          // only trigger a warning about the wrapper div if we already have a reference to it
           console.warn('Wrapper div has no height or width, try overriding style with `containerStyle` option')
         }
         return (


### PR DESCRIPTION
Only give warnings about dimensions once we have a reference to our wrapper div, to avoid emitting warnings for the first render cycle
