### PR TITLE
Fix default export - module.exports doesn't work with TypeScript

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -73,7 +73,7 @@ function defaultGetDimensions (element) {
  * module.exports = Dimensions()(MyComponent) // Enhanced component
  *
  */
-module.exports = function Dimensions ({
+export default function ({
     getDimensions = defaultGetDimensions,
     debounce = 0,
     debounceOpts = {},


### PR DESCRIPTION
[Disclosure] I'm really not an expert of ES6/node module internals. 
I'm using react-dimensions on a project that I'm moving step-by-step to TypeScript.
With the current code
`
import Dimensions from 'react-dimensions';
`
will import the function as expected in ES6/Babel code, but will be undefined with TypeScript.
This patch fixes the problem.
