### PR TITLE
Add unbind action for element-resize-event

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,6 +1,7 @@
 const _debounce = require('lodash.debounce')
 const React = require('react')
 const onElementResize = require('element-resize-event')
+const unbind = require('element-resize-event').unbind
 
 function defaultGetDimensions (element) {
   return [element.clientWidth, element.clientHeight]
@@ -139,9 +140,12 @@ module.exports = function Dimensions ({
       }
 
       componentWillUnmount () {
-        this.getWindow().removeEventListener('resize', this.onResize)
-        // TODO: remote element-resize-event listener.
-        // pending https://github.com/KyleAMathews/element-resize-event/issues/2
+        this._parent = this.refs.wrapper.parentNode
+        if (elementResize) {
+          unbind(this._parent)
+        } else {
+          this.getWindow().removeEventListener('resize', this.onResize)
+        }
       }
 
       /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "element-resize-event": "^2.0.4",
+    "element-resize-event": "^2.0.8",
     "lodash.debounce": "^4.0.6"
   }
 }


### PR DESCRIPTION
The element-resize-event library recently added `.unbind` functionality. The element-resize-event implementation is buggy without it and throws errors when changing components.